### PR TITLE
tornando possível continuar o jogo em um canal privado

### DIFF
--- a/definições.py
+++ b/definições.py
@@ -1,7 +1,7 @@
 frases = {
     'inventario_insuficiente': 'Sem os recursos necessários para avançar.',
-    'canal_privado': 'Por favor, envie mensagens para mim através de canal compartilhado de texto (não pvt).',
-    'sem_canal_de_voz': 'Por favor, esteja em um canal de voz para ter a imersão necessária do jogo.',
+    'canal_privado': 'Não é possível reproduzir áudio em canais privados.',
+    'sem_canal_de_voz': 'Por favor, esteja em um canal de voz para ter a imersão completa do jogo.',
     'erro': 'I\'m sorry Dave, I\'m afraid I can\'t do that.'
 }
 


### PR DESCRIPTION
# O que fiz
Adicionei algumas verificações que possibilitam o jogo continuar normalmente mesmo que os comandos sejam mandados diretamente para o bot.

- Verifico se a origem da mensagem é de um canal privado, então aviso ao jogador, mas deixo aberta a sessão caso ele queira continuar jogando sem a experiência completa.
- Verifico se a mensagem foi enviada de um canal privado antes de tentar reproduzir os sons da cena.
- Mudei a ordem do código, criando a "partida" antes mesmo de verificar a origem da mensagem